### PR TITLE
lower case file name is essential for linux compilation

### DIFF
--- a/pafish/gensandbox.c
+++ b/pafish/gensandbox.c
@@ -1,6 +1,6 @@
 
 #include <windows.h>
-#include <WinIoCtl.h>
+#include <winioctl.h>
 #include <string.h>
 
 #include "gensandbox.h"


### PR DESCRIPTION
A simple fix required to compile on linux (ubuntu)
