### PR TITLE
Bugfix: Restore Command Line Color Scheme

### DIFF
--- a/pafish/common.c
+++ b/pafish/common.c
@@ -8,7 +8,6 @@
 
 unsigned short init_cmd_colors() {
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
-	unsigned short original_colors = 0;
 	HANDLE handler = GetStdHandle(STD_OUTPUT_HANDLE);
 	// Get original console colors
 	GetConsoleScreenBufferInfo(handler, &csbi);

--- a/pafish/common.c
+++ b/pafish/common.c
@@ -6,9 +6,21 @@
 
 #include "common.h"
 
-void init_cmd_colors() {
+unsigned short init_cmd_colors() {
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	unsigned short original_colors = 0;
 	HANDLE handler = GetStdHandle(STD_OUTPUT_HANDLE);
+	// Get original console colors
+	GetConsoleScreenBufferInfo(handler, &csbi);
 	SetConsoleTextAttribute(handler, FOREGROUND_INTENSITY);
+	// Return original console colors
+	return csbi.wAttributes;
+}
+
+void restore_cmd_colors(unsigned short original_colors) {
+	HANDLE handler = GetStdHandle(STD_OUTPUT_HANDLE);
+	// Restore original console colors
+	SetConsoleTextAttribute(handler, original_colors);
 }
 
 void print_header() {

--- a/pafish/common.h
+++ b/pafish/common.h
@@ -2,7 +2,9 @@
 #ifndef COMM_H
 #define COMM_H
 
-void init_cmd_colors();
+unsigned short init_cmd_colors();
+
+void restore_cmd_colors(unsigned short);
 
 void print_header();
 

--- a/pafish/main.c
+++ b/pafish/main.c
@@ -36,10 +36,11 @@ int main(int argc, char *argv[])
 {
 	char icon[] = "Blue fish icon thanks to http://www.fasticon.com/", winverstr[32], aux[1024];
 	OSVERSIONINFO winver;
+	unsigned short original_colors = 0;
 
 	write_log("Start");
 
-	init_cmd_colors();
+	original_colors = init_cmd_colors();
 	print_header();
 
 	winver.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
@@ -335,6 +336,8 @@ int main(int argc, char *argv[])
 
 	fflush(stdin);
 	getchar();
+	/* Restore Original Console Colors */
+	restore_cmd_colors(original_colors);
 
 	return 0;
 }


### PR DESCRIPTION
pafish modifies the command-line color scheme but does not restore
it after execution. This commit fixes the issue.