### PR TITLE
Disabled Wow64 file system redirection

### DIFF
--- a/pafish/utils.c
+++ b/pafish/utils.c
@@ -7,6 +7,53 @@
 #include "utils.h"
 #include "types.h"
 
+/**
+ * Prototypes for the Wow64 API's since they aren't available in all Windows
+ * versions, most notetably Windows XP 32 bits.
+ */
+typedef int (WINAPI *DisableWow64FsRedirectionProto) (void*);
+
+typedef int (WINAPI *RevertWow64FsRedirectionProto) (void*);
+
+typedef int (WINAPI *IsWow64ProcessProto) (HANDLE, int*);
+
+/**
+ * Wrapper function for Wow64DisableWow64FsRedirection. The function returns
+ * FALSE if the Wow64DisableWow64FsRedirection is not found or the invocation
+ * fails. The old value is returned in the argument old.
+ */
+int pafish_disable_wow64_fs_redirection(void * old) {
+	DisableWow64FsRedirectionProto fndisable = (DisableWow64FsRedirectionProto) GetProcAddress(
+		GetModuleHandleA("kernel32"), "Wow64DisableWow64FsRedirection");
+
+	return (fndisable != NULL) && (fndisable(old) != 0) ? TRUE : FALSE;
+}
+/**
+ * Wrapper function for Wow64RevertWow64FsRedirection. The function returns
+ * FALSE if the Wow64RevertWow64FsRedirection is not found or the invocation
+ * fails. The old value is to be provided using the argument old.
+ */
+int pafish_revert_wow64_fs_redirection(void * old) {
+	RevertWow64FsRedirectionProto fnrevert = (RevertWow64FsRedirectionProto) GetProcAddress(
+		GetModuleHandleA("kernel32"), "Wow64RevertWow64FsRedirection");
+
+	return (fnrevert != NULL) && (fnrevert(old) != 0) ? TRUE : FALSE;
+}
+
+/**
+ * Wrapper function for IsWow64Process. The function returns TRUE if the
+ * current process is running under Wow64, FALSE otherwise or if the
+ * invocation failed.
+ */
+int pafish_iswow64() {
+	int result = FALSE;
+
+	IsWow64ProcessProto fniswow = (IsWow64ProcessProto) GetProcAddress(
+		GetModuleHandleA("kernel32"), "IsWow64Process");
+
+	return (fniswow != NULL) && (fniswow(GetCurrentProcess(), &result) != 0)  ? result : FALSE;
+}
+
 inline int pafish_exists_regkey(HKEY hKey, char * regkey_s) {
 	HKEY regkey;
 	LONG ret;
@@ -55,6 +102,23 @@ inline int pafish_exists_regkey_value_str(HKEY hKey, char * regkey_s, char * val
 }
 
 inline int pafish_exists_file(char * filename) {
-	return (GetFileAttributes(filename) != INVALID_FILE_ATTRIBUTES) ? TRUE : FALSE;
+	DWORD res = INVALID_FILE_ATTRIBUTES;
+
+	if (pafish_iswow64() == TRUE) {
+		void *old = NULL;
+
+		//  Disable redirection immediately prior to calling GetFileAttributes.
+		if (pafish_disable_wow64_fs_redirection(&old) ) {
+			res = GetFileAttributes(filename);
+
+			// Ignoring MSDN recommendation of exiting if this call fails.
+			pafish_revert_wow64_fs_redirection(old);
+		}
+	}
+	else {
+		res = GetFileAttributes(filename);
+	}
+
+	return (res != INVALID_FILE_ATTRIBUTES) ? TRUE : FALSE;
 }
 

--- a/pafish/utils.h
+++ b/pafish/utils.h
@@ -2,6 +2,12 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+int pafish_disable_wow64_fs_redirection(void * old);
+
+int pafish_revert_wow64_fs_redirection(void * old);
+
+int pafish_iswow64();
+
 inline int pafish_exists_regkey(HKEY hKey, char * regkey);
 
 inline int pafish_exists_regkey_value_str(HKEY, char *, char *, char *);


### PR DESCRIPTION
- When running pafish in a 64 bits sandbox many file checks failed;
- This will allow for pafish to access the native system32 directory.

I noticed this behaviour when testing pull request #31, since all my sandboxes are 64 bits.