### PR TITLE
Fix compiler warnings v1

### DIFF
--- a/pafish/utils.c
+++ b/pafish/utils.c
@@ -12,8 +12,13 @@
 #include "utils.h"
 #include "types.h"
 
+#ifndef KEY_WOW64_32KEY
 #define KEY_WOW64_32KEY 0x0200
+#endif
+
+#ifndef KEY_WOW64_64KEY
 #define KEY_WOW64_64KEY 0x0100
+#endif
 
 /**
  * Prototypes for the Wow64 API's since they aren't available in all Windows

--- a/pafish/utils.c
+++ b/pafish/utils.c
@@ -3,9 +3,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <winsock2.h>
 #include <windows.h>
 #include <ctype.h>
-#include <winsock2.h>
 #include <iphlpapi.h>
 #include <tlhelp32.h>
 


### PR DESCRIPTION
When cross compiling in Linux, MinGW produces the following warnings:

```
In file included from utils.c:8:0:
/usr/i686-w64-mingw32/usr/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
 #warning Please include winsock2.h before windows.h
  ^
utils.c:15:0: warning: "KEY_WOW64_32KEY" redefined
 #define KEY_WOW64_32KEY 0x0200
 ^
In file included from /usr/i686-w64-mingw32/usr/include/minwindef.h:163:0,
                 from /usr/i686-w64-mingw32/usr/include/windef.h:8,
                 from /usr/i686-w64-mingw32/usr/include/windows.h:69,
                 from utils.c:6:
/usr/i686-w64-mingw32/usr/include/winnt.h:7946:0: note: this is the location of the previous definition
 #define KEY_WOW64_32KEY (0x0200)
 ^
utils.c:16:0: warning: "KEY_WOW64_64KEY" redefined
 #define KEY_WOW64_64KEY 0x0100
 ^
In file included from /usr/i686-w64-mingw32/usr/include/minwindef.h:163:0,
                 from /usr/i686-w64-mingw32/usr/include/windef.h:8,
                 from /usr/i686-w64-mingw32/usr/include/windows.h:69,
                 from utils.c:6:
/usr/i686-w64-mingw32/usr/include/winnt.h:7945:0: note: this is the location of the previous definition
 #define KEY_WOW64_64KEY (0x0100)
 ^
```
This pull request fixes them.