### PR TITLE
HackingTeam VM detection

### DIFF
--- a/pafish/Makefile.linux
+++ b/pafish/Makefile.linux
@@ -6,7 +6,7 @@ OBJ       = Objects/MingW/main.o Objects/MingW/common.o Objects/MingW/utils.o Ob
             Objects/MingW/vbox.o Objects/MingW/gensandbox.o Objects/MingW/wine.o Objects/MingW/vmware.o \
             Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/pafish_private.res
 LINKOBJ   = $(OBJ)
-LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -s
+LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -lole32 -lwbemuuid -loleaut32 -s
 INCS      =
 BIN       = Output/MingW/pafish.exe
 CFLAGS    = $(INCS) -Wall -Wextra -O0

--- a/pafish/Makefile.linux
+++ b/pafish/Makefile.linux
@@ -4,7 +4,7 @@ LINK      = i686-w64-mingw32-gcc
 WINDRES   = i686-w64-mingw32-windres
 OBJ       = Objects/MingW/main.o Objects/MingW/common.o Objects/MingW/utils.o Objects/MingW/debuggers.o Objects/MingW/sandboxie.o \
             Objects/MingW/vbox.o Objects/MingW/gensandbox.o Objects/MingW/wine.o Objects/MingW/vmware.o \
-            Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/pafish_private.res
+            Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/cuckoo.o Objects/MingW/pafish_private.res
 LINKOBJ   = $(OBJ)
 LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -lole32 -lwbemuuid -loleaut32 -s
 INCS      =
@@ -56,6 +56,9 @@ Objects/MingW/hooks.o: $(GLOBALDEPS) hooks.c
 
 Objects/MingW/cpu.o: $(GLOBALDEPS) cpu.c
 	$(CC) -c cpu.c -o Objects/MingW/cpu.o $(CFLAGS)
+
+Objects/MingW/cuckoo.o: $(GLOBALDEPS) cuckoo.c
+	$(CC) -c cuckoo.c -o Objects/MingW/cuckoo.o $(CFLAGS)
 
 Objects/MingW/pafish_private.res: Objects/MingW/pafish_private.rc
 	$(WINDRES) Objects/MingW/pafish_private.rc --input-format=rc -o Objects/MingW/pafish_private.res -O coff

--- a/pafish/Makefile.win
+++ b/pafish/Makefile.win
@@ -4,7 +4,7 @@ LINK      = gcc.exe
 WINDRES   = windres.exe
 OBJ       = Objects/MingW/main.o Objects/MingW/common.o Objects/MingW/utils.o Objects/MingW/debuggers.o Objects/MingW/sandboxie.o \
             Objects/MingW/vbox.o Objects/MingW/gensandbox.o Objects/MingW/wine.o Objects/MingW/vmware.o \
-            Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/pafish_private.res
+            Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/cuckoo.o Objects/MingW/pafish_private.res
 LINKOBJ   = $(OBJ)
 LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -lole32 -lwbemuuid -loleaut32 -s
 INCS      =
@@ -56,6 +56,9 @@ Objects/MingW/hooks.o: $(GLOBALDEPS) hooks.c
 
 Objects/MingW/cpu.o: $(GLOBALDEPS) cpu.c
 	$(CC) -c cpu.c -o Objects/MingW/cpu.o $(CFLAGS)
+
+Objects/MingW/cuckoo.o: $(GLOBALDEPS) cuckoo.c
+	$(CC) -c cuckoo.c -o Objects/MingW/cuckoo.o $(CFLAGS)
 
 Objects/MingW/pafish_private.res: Objects/MingW/pafish_private.rc
 	$(WINDRES) Objects/MingW/pafish_private.rc --input-format=rc -o Objects/MingW/pafish_private.res -O coff

--- a/pafish/Makefile.win
+++ b/pafish/Makefile.win
@@ -6,7 +6,7 @@ OBJ       = Objects/MingW/main.o Objects/MingW/common.o Objects/MingW/utils.o Ob
             Objects/MingW/vbox.o Objects/MingW/gensandbox.o Objects/MingW/wine.o Objects/MingW/vmware.o \
             Objects/MingW/qemu.o Objects/MingW/hooks.o Objects/MingW/cpu.o Objects/MingW/pafish_private.res
 LINKOBJ   = $(OBJ)
-LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -s
+LIBS      = -lwsock32 -liphlpapi -lsetupapi -lmpr -lole32 -lwbemuuid -loleaut32 -s
 INCS      =
 BIN       = Output/MingW/pafish.exe
 CFLAGS    = $(INCS) -Wall -Wextra -O0

--- a/pafish/cuckoo.c
+++ b/pafish/cuckoo.c
@@ -1,0 +1,64 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "types.h"
+#include "cuckoo.h"
+
+/**
+ * Cuckoo Sandbox definitions.
+ */
+/**
+ * Extra space allocated with the hooks information structure.
+ */
+#define TLS_HOOK_INFO_RETADDR_SPACE 0x100
+
+/**
+ * Hook informnation stored by Cuckoo at FS:[TLS_HOOK_INFO].
+ */
+struct hook_info {
+	unsigned int depth_count;
+	unsigned int hook_count;
+	unsigned int retaddr_esp;
+	unsigned int last_error;
+	unsigned int ret_last_error;
+	unsigned int eax;
+	unsigned int ecx;
+	unsigned int edx;
+	unsigned int ebx;
+	unsigned int esp;
+	unsigned int ebp;
+	unsigned int esi;
+	unsigned int edi;
+};
+
+/**
+ * Read the address of the hooks information in the TLS.
+ */
+struct hook_info *read_hook_info() {
+	void *result = NULL;
+
+	__asm__ volatile ("mov %%fs:0x44,%%eax" : "=a" (result));
+
+	return result;
+}
+
+/**
+ * Cuckoo stores the return addresses in a extra space allocated in conjunction
+ * with the hook information function. The only way to check if the structure
+ * is valid is to calculate what is the minimum and maximum value for the
+ * return address value location.
+ */
+int cuckoo_check_tls() {
+	struct hook_info *info = read_hook_info();
+
+	if (info == NULL) {
+		return FALSE;
+	}
+
+	unsigned int minimum = ((unsigned int) info + sizeof(struct hook_info));
+	unsigned int maximum = minimum + TLS_HOOK_INFO_RETADDR_SPACE;
+
+	return (info != NULL) && (info->retaddr_esp >= minimum && info->retaddr_esp <= maximum) ?
+		TRUE : FALSE;
+}

--- a/pafish/cuckoo.h
+++ b/pafish/cuckoo.h
@@ -1,0 +1,8 @@
+
+#ifndef CUCKOO_H
+#define CUCKOO_H
+
+int cuckoo_check_tls();
+
+#endif
+ 

--- a/pafish/gensandbox.c
+++ b/pafish/gensandbox.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <wbemidl.h>
 
 #include "types.h"
 #include "gensandbox.h"

--- a/pafish/main.c
+++ b/pafish/main.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <windows.h>
+#include <wbemidl.h>
 
 #include "types.h"
 #include "common.h"
@@ -367,6 +368,14 @@ int main(void)
 	}
 	else print_not_traced();
 
+	printf("[*] Looking for VBox devices using WMI ... ");
+	if (vbox_wmi_devices() == TRUE) {
+		write_log("VirtualBox device identifiers traced using WMI");
+		print_traced();
+		write_trace("hi_virtualbox_wmi");
+	}
+	else print_not_traced();
+
 	/* VMware detection tricks */
 	printf("\n[-] VMware detection\n");
 	printf("[*] Scsi port 0,1,2 ->bus->target id->logical unit id-> 0 identifier ... ");
@@ -414,6 +423,14 @@ int main(void)
 		/* Log written inside function */
 		print_traced();
 		write_trace("hi_vmware");
+	}
+	else print_not_traced();
+
+	printf("[*] Looking for VMware serial number ... ");
+	if (vmware_wmi_serial() == TRUE) {
+		write_log("VMware serial number traced using WMI");
+		print_traced();
+		write_trace("hi_vmware_wmi");
 	}
 	else print_not_traced();
 

--- a/pafish/main.c
+++ b/pafish/main.c
@@ -17,6 +17,7 @@
 #include "vmware.h"
 #include "qemu.h"
 #include "cpu.h"
+#include "cuckoo.h"
 
 /*
 	Pafish (Paranoid fish)
@@ -449,6 +450,16 @@ int main(void)
 		write_log("Qemu traced using Reg key HKLM\\HARDWARE\\Description\\System \"SystemBiosVersion\"");
 		print_traced();
 		write_trace("hi_qemu");
+	}
+	else print_not_traced();
+
+	/* Cuckoo detection tricks */
+	printf("\n[-] Cuckoo detection\n");
+	printf("[*] Looking in the TLS for the hooks information structure ... ");
+	if (cuckoo_check_tls() == TRUE) {
+		write_log("Cuckoo hooks information structure traced in the TLS");
+		print_traced();
+		write_trace("hi_cuckoo");
 	}
 	else print_not_traced();
 

--- a/pafish/qemu.c
+++ b/pafish/qemu.c
@@ -1,6 +1,7 @@
 
 #include <windows.h>
 #include <string.h>
+#include <wbemidl.h>
 
 #include "qemu.h"
 #include "types.h"

--- a/pafish/utils.h
+++ b/pafish/utils.h
@@ -16,4 +16,17 @@ inline int pafish_exists_file(char * filename);
 
 int pafish_check_mac_vendor(char * mac_vendor);
 
+/**
+ * Prototype for the WMI caller implemented function for checking the
+ * WMI query results.
+ */
+typedef int (*wmi_check_row) (IWbemClassObject *);
+
+int wmi_initialize(const wchar_t *, IWbemServices **);
+
+int wmi_check_query(IWbemServices *, const wchar_t *, const wchar_t *,
+	wmi_check_row check_row);
+
+void wmi_cleanup(IWbemServices *);
+
 #endif

--- a/pafish/vbox.h
+++ b/pafish/vbox.h
@@ -25,4 +25,6 @@ int vbox_network_share();
 
 int vbox_processes(int writelogs);
 
+int vbox_wmi_devices();
+
 #endif

--- a/pafish/vmware.h
+++ b/pafish/vmware.h
@@ -14,4 +14,6 @@ int vmware_mac();
 
 int vmware_devices();
 
+int vmware_wmi_serial();
+
 #endif

--- a/pafish/wine.c
+++ b/pafish/wine.c
@@ -1,5 +1,6 @@
 
 #include <windows.h>
+#include <wbemidl.h>
 
 #include "wine.h"
 #include "types.h"


### PR DESCRIPTION
This implements enhancement #38. Added HackingTeam anti-VM WMI checks and transformed the anti-Cuckoo function to a check. The WMI checks are:
- VirtualBox devices identifier;
- VMWare serial number.

For the WMI checks, HackingTeam uses SHA1 values to do the comparison, Pafish can get away from this (using string comparison) since there is no need to hide strings. For the anti-Cuckoo, HackingTeam was happy enough to crash Cuckoo by replacing the hook information pointer with one that points to a buffer filled with one's. Pafish on the other hand, will check if the pointer isn't null and if it points to a valid hook information structure. To check if the structure is valid, it checks the value that will surely crash Cuckoo if changed: location in the stack of the next return address.